### PR TITLE
FIX[#21]: Update ecoindex.fr link

### DIFF
--- a/lighthouse-plugin-ecoindex/cli/templates/fr_FR/html.handlebars
+++ b/lighthouse-plugin-ecoindex/cli/templates/fr_FR/html.handlebars
@@ -143,7 +143,7 @@
     </ul>
     <h2>Méthode d'évaluation</h2>
     <p>Comme toute production numérique, ce site web a un impact environnemental que nous vous présentons sur cette page à l’aide d’indicateurs standardisés.</p>
-    <p>Nous utilisons le référentiel <a href="http://www.ecoindex.fr/quest-ce-que-ecoindex/" target="_blank" rel="noopener" title="EcoIndex (nouvelle fenêtre)">EcoIndex</a> proposé par le collectif <a href="https://www.greenit.fr/" target="_blank" rel="noopener" title="GreenIT.fr (nouvelle fenêtre)">GreenIT.fr</a>, pour évaluer la performance environnementale de ce site web. Celui-ci est quantifié grâce à deux types d'indicateurs : </p>
+    <p>Nous utilisons le référentiel <a href="https://www.ecoindex.fr/comment-ca-marche/" target="_blank" rel="noopener" title="EcoIndex (nouvelle fenêtre)">EcoIndex</a> proposé par le collectif <a href="https://www.greenit.fr/" target="_blank" rel="noopener" title="GreenIT.fr (nouvelle fenêtre)">GreenIT.fr</a>, pour évaluer la performance environnementale de ce site web. Celui-ci est quantifié grâce à deux types d'indicateurs : </p>
     <ul>
       <li>
         <strong>Niveau d’écoconception du site web.</strong>Cet indicateur évalue la mise en place de bonnes pratiques permettant de réduire l'impact d'une page web. Le niveau atteint est représenté par une évaluation relative de A à G (A est la meilleure note) associée à un score absolu de 0 à 100 (100 est la meilleure note).
@@ -322,7 +322,7 @@
       <strong>Pour en savoir plus sur EcoIndex :</strong>
     </h3>
     <p>
-      <a href="http://www.ecoindex.fr/quest-ce-que-ecoindex/" target="_blank" rel="noopener" title="En savoir plus sur le référentiel EcoIndex (nouvelle fenêtre)">En savoir plus sur le référentiel EcoIndex</a>
+      <a href="https://www.ecoindex.fr/comment-ca-marche/" target="_blank" rel="noopener" title="En savoir plus sur le référentiel EcoIndex (nouvelle fenêtre)">En savoir plus sur le référentiel EcoIndex</a>
     </p>
     <p>
       <a href="http://www.ecoindex.fr/" target="_blank" rel="noopener" title="Accéder au site web EcoIndex (nouvelle fenêtre)">Accéder au site web EcoIndex</a>

--- a/lighthouse-plugin-ecoindex/cli/templates/fr_FR/markdown.handlebars
+++ b/lighthouse-plugin-ecoindex/cli/templates/fr_FR/markdown.handlebars
@@ -25,7 +25,7 @@ Mesure effectuée le {{ toDateString date }}.
 ![Note G](https://raw.githubusercontent.com/cnumr/lighthouse-plugin-ecoindex/main/assets/Note-G.webp)
 {{/ifEquals}}
 * Note Ecoindex : **{{ best_pages.summary.[eco-index-score] }}/100**
-* Consommation d'eau moyenne rapportée à 1 000 utilisateurs (en litres) : **{{ best_pages.summary.[eco-index-water] }} litres, (soit {{ best_pages.summary.[eco-index-water-equivalent] }} packs d'eau minérale).*** 
+* Consommation d'eau moyenne rapportée à 1 000 utilisateurs (en litres) : **{{ best_pages.summary.[eco-index-water] }} litres, (soit {{ best_pages.summary.[eco-index-water-equivalent] }} packs d'eau minérale).***
 * Émission de Gaz à Effet de Serre (GES) moyenne rapportée à 1 000 utilisateurs (kilos CO2e) : **{{ best_pages.summary.[eco-index-ghg] }} kilos CO2e (soit un trajet de {{ best_pages.summary.[eco-index-ghg-equivalent] }} kms en voiture à énergie thermique).***
 ## Méthode d'évaluation
 Comme toute production numérique, ce site web a un impact environnemental que nous vous présentons sur cette page à l’aide d’indicateurs standardisés.
@@ -53,7 +53,7 @@ L'analyse indiquée a été effectuée le {{ toDateString date }}, elle est susc
 
 * Consommation d'eau rapportée à 1 000 utilisateurs (en litres) : {{ this.[eco-index-water] }} (soit {{ this.[eco-index-water-equivalent] }} packs d'eau minérale).
 * Émission de GES rapportée à 1 000 utilisateurs (kilos CO2e) : {{ this.[eco-index-ghg] }} (soit un trajet de {{ this.[eco-index-ghg-equivalent] }} kms en voiture à énergie thermique).
-	
+
 {{/each}}
 ## Evaluation de l'impact pour 5 parcours utilisateurs sur le site
 {{#each courses}}
@@ -139,7 +139,7 @@ Vous êtes un professionnel du numérique et vous souhaitez réduire l’impact 
 
 ### Pour en savoir plus sur EcoIndex :
 
-* [En savoir plus sur le référentiel EcoIndex](http://www.ecoindex.fr/quest-ce-que-ecoindex/)
+* [En savoir plus sur le référentiel EcoIndex](https://www.ecoindex.fr/comment-ca-marche/)
 * [Accéder au site web EcoIndex](https://www.ecoindex.fr/)
 
 _*Moyenne de l’impact environnemental des 5 pages les plus visitées ce site web._


### PR DESCRIPTION
- http://www.ecoindex.fr/quest-ce-que-ecoindex/ is 404 and not redirected
- https://www.ecoindex.fr/comment-ca-marche/ seems to be the new page describing EcoIndex